### PR TITLE
Move docs site to subdirectory

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,7 @@ const withNextra = nextra({
 });
 
 const nextConfig = withNextra({
+  basePath: "/docs",
   output: "standalone",
 });
 


### PR DESCRIPTION
Moving docs website from docs.drpc.org to drpc.org/docs.
This PR should be merged together with this one: https://github.com/drpcorg/devops-drpc-infra/pull/1224
First this nextra PR, after that infra PR.