### PR TITLE
Typo in the price-configuration.mdx

### DIFF
--- a/pages/providers/price-configuration.mdx
+++ b/pages/providers/price-configuration.mdx
@@ -20,7 +20,7 @@ But providers can redefine those values for themselves through provider dashboar
 ## CU lang
 
 We provide a small configuration language that allows to set prices.
-If you're familiar with CSS, it's very similar and allows you to easily augment prices for borad range of methods.
+If you're familiar with CSS, it's very similar and allows you to easily augment prices for board range of methods.
 
 ### Example
 


### PR DESCRIPTION
Fixed **"borad"** → **"board"** for better clarity.
